### PR TITLE
fix: Make daily periodic scheduler to work in older than 'S' Android versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed bullet points rendering for Arabic locale
+- Made daily periodic scheduler to work in older than 'S' Android versions
 
 ## [1.1.0] - 2025-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed bullet points rendering for Arabic locale
-- Made daily periodic scheduler to work in older than 'S' Android versions
+- Fixed daily periodic scheduler on Android 11 and below which prevented the widget from updating the date automatically. 
 
 ## [1.1.0] - 2025-10-15
 

--- a/app/src/main/kotlin/me/amrbashir/hijriwidget/android/AlarmReceiver.kt
+++ b/app/src/main/kotlin/me/amrbashir/hijriwidget/android/AlarmReceiver.kt
@@ -7,8 +7,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.icu.util.Calendar
-import android.os.Build
 import android.util.Log
+import androidx.core.app.AlarmManagerCompat
+import androidx.core.content.getSystemService
 import kotlinx.coroutines.runBlocking
 import me.amrbashir.hijriwidget.PreferencesManager
 import me.amrbashir.hijriwidget.logTimestamp
@@ -48,11 +49,8 @@ class AlarmReceiver : BroadcastReceiver() {
         }
 
         fun setup24Periodic(context: Context, prefsManager: PreferencesManager) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
-
-            val service = Context.ALARM_SERVICE
-            val alarmManager = context.getSystemService(service) as AlarmManager? ?: return
-            if (!alarmManager.canScheduleExactAlarms()) return
+            val alarmManager = context.getSystemService<AlarmManager>() ?: return
+            if (!AlarmManagerCompat.canScheduleExactAlarms(alarmManager)) return
 
             val nextUpdateMillis = nextUpdateDateInMillis(prefsManager)
 


### PR DESCRIPTION
This makes use of AlarmManagerCompat.canScheduleExactAlarms to make the logic work in older Android versions also.