### PR TITLE
Remove unused resources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 
         release {
             isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("config")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
In my testing this decreases the size of the resulting APK from 4,639,054 bytes to 3,963,935 bytes.

It's a common practice as far I can say but totally understandable if you don't like it.